### PR TITLE
schema: Generalize descriptions for locations to be applicable in generic contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 * Deprecate the `Item.deliveryAddress` field in favor of the new `Item.deliveryAddresses` field, to support items with multiple delivery addresses
 * Deprecate the `Item.deliveryLocation` field in favor of the new `Item.deliveryLocations` field, to support items with multiple delivery locations
 * Add "format": "uri" to `Location.uri`
-* Update GeoJSON reference links in `Location.geometry`
+* Update field descriptions to allow location objects to be used in other contexts than deliveries
 
 ### v1.1.5
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If the procurement related to the rebuilding of a road, then the item could also
       {
         "id": "item1",
         "deliveryLocations": [
-            {
+          {
             "geometry": {
               "type": "LineString",
               "coordinates": [

--- a/release-schema.json
+++ b/release-schema.json
@@ -42,7 +42,7 @@
           "$ref": "#/definitions/Location",
           "deprecated": {
             "description": "This field is deprecated in favour of `.deliveryLocations` to support items with multiple delivery locations.",
-            "deprecatedVersion": "1.1.6"
+            "deprecatedVersion": "1.2.0"
           }
         },
         "deliveryAddresses": {
@@ -61,7 +61,7 @@
           "$ref": "#/definitions/Address",
           "deprecated": {
             "description": "This field is deprecated in favour of `.deliveryAddresses` to support items with multiple delivery locations.",
-            "deprecatedVersion": "1.1.6"
+            "deprecatedVersion": "1.2.0"
           }
         }
       }

--- a/release-schema.json
+++ b/release-schema.json
@@ -68,8 +68,8 @@
     },
     "Location": {
       "type": "object",
-      "title": "Delivery Location",
-      "description": "The location where activity related to this tender, contract or license will be delivered, or will take place. A location can be described by either a geometry (point location, line or polygon), or a gazetteer entry, or both.",
+      "title": "Location",
+      "description": "A physical or virtual location.",
       "properties": {
         "description": {
           "title": "Description",
@@ -82,7 +82,7 @@
         "geometry": {
           "type": "object",
           "title": "Geometry",
-          "description": "We follow the [GeoJSON standard](https://www.rfc-editor.org/rfc/rfc7946) to express basic location information, using longitude, latitude, and optional elevation values in the [WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System) (EPSG:4326) projection. A point location can be identified by geocoding a delivery address. For concession licenses, or other contracts covering a polygon location which is not contained in a known gazetteer, polygon and multi-polygon can be used.",
+          "description": "We follow the [GeoJSON standard](https://www.rfc-editor.org/rfc/rfc7946) to express basic location information, using longitude, latitude, and optional elevation values in the [WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System) (EPSG:4326) projection. A point location can be identified by geocoding an address. For concession licenses, or other scenarios covering a polygon location that is not contained in a known gazetteer, polygon and multi-polygon can be used.",
           "properties": {
             "type": {
               "title": "Type",
@@ -154,7 +154,7 @@
           ],
           "format": "uri",
           "title": "URI",
-          "description": "A URI to a further description of the activity location. This might be a human-readable document with information on the location, or a machine-readable description of the location."
+          "description": "A URI to a further description of the location. This might be a human-readable document with information on the location, or a machine-readable description of the location."
         }
       }
     }


### PR DESCRIPTION
closes open-contracting/ocds-extensions#187

Might need to manually close it - not sure if automation works across organizations.